### PR TITLE
ignore application-context(oracleDB Setting)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.metadata/
+application-context.xml


### PR DESCRIPTION
DB 설정(오라클 경로)이 꼬여서 해당 파일을 제외하고 commit이 가능하게 한다.